### PR TITLE
Jaina/Sylvanas in Forge of Souls

### DIFF
--- a/scripts/northrend/icecrown_citadel/frozen_halls/forge_of_souls/forge_of_souls.cpp
+++ b/scripts/northrend/icecrown_citadel/frozen_halls/forge_of_souls/forge_of_souls.cpp
@@ -252,7 +252,7 @@ uint32 uiSummon_counter;
             }
             else Step = 10;
             StepTimer = 100;
-            m_creature->SetVisibility(VISIBILITY_OFF);
+            m_creature->SetVisibility(VISIBILITY_ON);
         }
     }
 


### PR DESCRIPTION
I know this is a very little patch. I don't know if send a pull request is useful.
This patch set Jaina or Sylvanas visibility when Devourer of souls die. If they are visibles, we can give back a quest to them and start a new quest.

Tell me if you want pulls requests more useful.
